### PR TITLE
Fix insert off by one error

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -459,9 +459,9 @@ class Collection implements Countable, IteratorAggregate
      */
     private function validateIndex($index)
     {
-        $exists = $this->indexInsertable($index);
+        $insertable = $this->indexInsertable($index);
 
-        if (!$exists) {
+        if (!$insertable) {
             throw new OutOfRangeException("Index out of bounds of collection");
         }
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -431,12 +431,12 @@ class Collection implements Countable, IteratorAggregate
     }
 
     /**
-     * Return whether the given index exists
+     * Return whether the given index is insertable
      *
      * @param integer $index The number to be validated as an index
      * @return bool
      */
-    public function indexExists($index)
+    public function indexInsertable($index)
     {
        if (!is_int($index)) {
             throw new InvalidArgumentException("Index must be an integer");
@@ -446,7 +446,7 @@ class Collection implements Countable, IteratorAggregate
             throw new InvalidArgumentException("Index must be a non-negative integer");
         }
 
-        return $index < $this->count();
+        return $index <= $this->count();
     }
 
 
@@ -459,7 +459,7 @@ class Collection implements Countable, IteratorAggregate
      */
     private function validateIndex($index)
     {
-        $exists = $this->indexExists($index);
+        $exists = $this->indexInsertable($index);
 
         if (!$exists) {
             throw new OutOfRangeException("Index out of bounds of collection");

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -28,7 +28,7 @@ class ControllerTest extends PHPUnit_Framework_TestCase {
     $this->c->add($a);
 
     $this->setExpectedException("Collections\Exceptions\OutOfRangeException");
-    $result = $this->c->at(1);
+    $result = $this->c->at(2);
   }
 
   public function testAddAndRetrieveFunctions(){
@@ -444,28 +444,29 @@ class ControllerTest extends PHPUnit_Framework_TestCase {
       $this->assertFalse($this->c->at(0) === $c->at(0));
   }
 
-  public function testIndexExits()
+  public function testIndexInsertable()
   {
       $t = new TestClassA(1);
       $t2 = new TestClassA(2);
       $this->c->add($t);
       $this->c->add($t2);
 
-      $this->assertTrue($this->c->indexExists(0));
-      $this->assertTrue($this->c->indexExists(1));
-      $this->assertFalse($this->c->indexExists(2));
+      $this->assertTrue($this->c->indexInsertable(0));
+      $this->assertTrue($this->c->indexInsertable(1));
+      $this->assertTrue($this->c->indexInsertable(2));
+      $this->assertFalse($this->c->indexInsertable(3));
   }
   
   public function testIndexExitsRejectsNegatives()
   {
       $this->setExpectedException("Collections\Exceptions\InvalidArgumentException");
-      $this->c->indexExists(-1);
+      $this->c->indexInsertable(-1);
   }
 
   public function testIndexExitsRejectsNonIntegers()
   {
       $this->setExpectedException("Collections\Exceptions\InvalidArgumentException");
-      $this->c->indexExists("wat");
+      $this->c->indexInsertable("wat");
   }
 
   public function testReduce()

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -259,6 +259,15 @@ class ControllerTest extends PHPUnit_Framework_TestCase {
     $this->c->insert(-1, new TestClassA(5));
   }
 
+  public function testInsertEnd(){
+    $this->c->add(new TestClassA(1));
+    $this->c->add(new TestClassA(2));
+
+    $this->c->insert(2,new TestClassA(3));
+
+    $this->assertEquals(3,$this->c->at(2)->getValue());
+  }
+
   public function testInsertRange(){
     $this->c->add(new TestClassA(1));
     $this->c->add(new TestClassA(2));


### PR DESCRIPTION
The only concern I have is that `indexExists` was defined as public. Thus, implementations had access to it, and could be using it. So this change is a BC break. I'd suggestion version `1.6.0` because of this.

Otherwise, we can keep the existing method, make a new method for whether index is insertable, and maintain BC at the expense of maintaining a method we don't even use in the package.