### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library contains two collection classes: an array list, and a dictionary.
 Both of these classes are immutable. If you add or remove items from these collections,
 you will receive a new instance with the changes applied. 
 
-##Requirements##
+## Requirements ##
 
 Requires PHP 5.4 or greater, dev reqiures PHP 5.5 or greater.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
