### PR TITLE
Initialize Dictionary with an empty storage

### DIFF
--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -11,7 +11,7 @@ class Dictionary implements DictionaryInterface
 {
     use TypeValidator;
 
-    protected $storage;
+    protected $storage = [];
     protected $keyType;
     protected $valType;
 


### PR DESCRIPTION
Upon calling Dictionary::exists without having added any data to it, PHP would throw warnings about array_key_exists expecting an array as second parameter. Since $storage is always an array, initialize it as such.

Signed-off-by: Yoshi2889 <rick.2889@gmail.com>