### PR TITLE
Fix type does not exist error using map with empty Collection and Dictionary

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -501,6 +501,9 @@ class Collection implements CollectionInterface
             $items[] = $result;
         }
 
+        if (null === $type) {
+            $type = $this->type;
+        }
 
         $col = new static ($type);
         $col->setItemsFromTrustedSource($items);

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -214,6 +214,11 @@ class Dictionary implements DictionaryInterface
             $items[$k] = $v;
         }
 
+        if (null === $keyType && null === $valType) {
+            $keyType = $this->keyType;
+            $valType = $this->valType;
+        }
+
         return new static($keyType, $valType, $items);
     }
 

--- a/tests/Collection/MapTest.php
+++ b/tests/Collection/MapTest.php
@@ -72,4 +72,14 @@ class MapTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result);
 
     }
+
+    public function test_map_empty_collection()
+    {
+        $c = new Collection('string');
+        $result = $c->map(function ($a) {
+            return $a;
+        });
+        $expected = new Collection('string');
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/Dictionary/MapTest.php
+++ b/tests/Dictionary/MapTest.php
@@ -37,4 +37,14 @@ class MapTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(97, $m->get(1));
         $this->assertEquals(98, $m->get(2));
     }
+
+    public function test_map_empty_dictionary()
+    {
+        $d = new Dictionary('string', 'int');
+        $result = $d->map(function ($a) {
+            return $a;
+        });
+        $expected = new Dictionary('string', 'int');
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
If trying to map on an empty Collection, or a Dictionary without any entries, map() would throw a `This type does not exist.` error. This PR addresses that error by setting the type of the returned Collection / Dictionary to the current type.