### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - '7.0'
 
 before_script:
-  - composer install 
+  - composer install
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
        }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.3",
+        "phpunit/phpunit": "^5.4.3",
         "squizlabs/php_codesniffer": "2.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,22 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "870859fabc3a9e63dae0871fd25cff05",
-    "content-hash": "c5d0c7e7bc2722e1ab4dbb2ffdbc7480",
+    "content-hash": "857f435e5c1c4381240650aa69eff1c6",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "dev-master",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "416fb8ad1d095a87f1d21bc40711843cd122fd4a"
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/416fb8ad1d095a87f1d21bc40711843cd122fd4a",
-                "reference": "416fb8ad1d095a87f1d21bc40711843cd122fd4a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
                 "shasum": ""
             },
             "require": {
@@ -60,7 +59,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2016-03-31 10:24:22"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -102,7 +101,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2015-11-20 12:04:31"
+            "time": "2015-11-20T12:04:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -151,7 +150,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2015-02-03T12:10:50+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -213,39 +212,39 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-05-27 08:33:35"
+            "time": "2016-05-27T08:33:35+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "dev-master",
+            "version": "4.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "844ec6eabee15768f1e34a8871f6fddfc3d5f602"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/844ec6eabee15768f1e34a8871f6fddfc3d5f602",
-                "reference": "844ec6eabee15768f1e34a8871f6fddfc3d5f602",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
                 "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "^1.4.2",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0|~2.0"
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "^5.4"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.4.0",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
@@ -276,7 +275,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-27 16:21:40"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -323,7 +322,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -364,7 +363,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -408,20 +407,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "dev-master",
+            "version": "1.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "cab6c6fefee93d7b7c3a01292a0fe0884ea66644"
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/cab6c6fefee93d7b7c3a01292a0fe0884ea66644",
-                "reference": "cab6c6fefee93d7b7c3a01292a0fe0884ea66644",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/58bd196ce8bc49389307b3787934a5117db80fea",
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea",
                 "shasum": ""
             },
             "require": {
@@ -457,20 +456,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-23 14:46:55"
+            "time": "2017-12-04T15:11:28+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "dev-master",
+            "version": "5.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c5f916fea37634a027b091d533fce4f7ff3f49fc"
+                "reference": "53951b4c305322d089cf5c02023eee5d7afa155f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c5f916fea37634a027b091d533fce4f7ff3f49fc",
-                "reference": "c5f916fea37634a027b091d533fce4f7ff3f49fc",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/53951b4c305322d089cf5c02023eee5d7afa155f",
+                "reference": "53951b4c305322d089cf5c02023eee5d7afa155f",
                 "shasum": ""
             },
             "require": {
@@ -482,20 +481,23 @@
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
+                "sebastian/environment": "^1.3 || ^2.0",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
                 "sebastian/object-enumerator": "~1.0",
                 "sebastian/resource-operations": "~1.0",
                 "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
             },
             "suggest": {
                 "phpunit/php-invoker": "~1.1"
@@ -532,7 +534,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-31 04:34:31"
+            "time": "2017-02-02T11:33:56+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -588,7 +590,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-05-26 06:15:46"
+            "time": "2016-05-26T06:15:46+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -633,26 +635,26 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
+            "time": "2016-02-13T06:45:14+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "dev-master",
+            "version": "1.2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "18a5d97c25f408f48acaf6d1b9f4079314c5996a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/18a5d97c25f408f48acaf6d1b9f4079314c5996a",
+                "reference": "18a5d97c25f408f48acaf6d1b9f4079314c5996a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -697,27 +699,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2017-03-07T10:34:43+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "dev-master",
+            "version": "1.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -749,27 +751,27 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "dev-master",
+            "version": "1.3.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "67f55699c2810ff0f2cc47478bbdeda8567e68ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/67f55699c2810ff0f2cc47478bbdeda8567e68ee",
+                "reference": "67f55699c2810ff0f2cc47478bbdeda8567e68ee",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -799,7 +801,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2017-02-28T08:18:59+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -866,7 +868,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-08-09 04:23:41"
+            "time": "2015-08-09T04:23:41+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -917,20 +919,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "dev-master",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+                "reference": "1a7e888dce73bd3c1deedb345fce00329c75b065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1a7e888dce73bd3c1deedb345fce00329c75b065",
+                "reference": "1a7e888dce73bd3c1deedb345fce00329c75b065",
                 "shasum": ""
             },
             "require": {
@@ -963,20 +965,20 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
+            "time": "2016-10-03T07:42:27+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "dev-master",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "7ff5b1b3dcc55b8ab8ae61ef99d4730940856ee7"
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/7ff5b1b3dcc55b8ab8ae61ef99d4730940856ee7",
-                "reference": "7ff5b1b3dcc55b8ab8ae61ef99d4730940856ee7",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
                 "shasum": ""
             },
             "require": {
@@ -1016,7 +1018,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-01-28 05:39:29"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1058,7 +1060,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1101,7 +1103,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2016-02-04T12:56:52+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1179,24 +1181,30 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-06-01 09:46:56"
+            "time": "2016-06-01T09:46:56+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "dev-master",
+            "version": "3.2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "737c6a22a9a2f6ac3d4c62a0b97720e139c4a093"
+                "reference": "78a0c5d7d43713212aac73d7c6a56754a5c26cea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/737c6a22a9a2f6ac3d4c62a0b97720e139c4a093",
-                "reference": "737c6a22a9a2f6ac3d4c62a0b97720e139c4a093",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/78a0c5d7d43713212aac73d7c6a56754a5c26cea",
+                "reference": "78a0c5d7d43713212aac73d7c6a56754a5c26cea",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
             "extra": {
@@ -1228,7 +1236,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-29 09:50:57"
+            "time": "2017-06-02T09:43:35+00:00"
         }
     ],
     "aliases": [],

--- a/tests/Collection/AccessTest.php
+++ b/tests/Collection/AccessTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class AccessTest extends PHPUnit_Framework_TestCase
+class AccessTest extends TestCase
 {
     /**
      * @expectedException Collections\Exceptions\InvalidArgumentException

--- a/tests/Collection/AddTest.php
+++ b/tests/Collection/AddTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class AddTest extends PHPUnit_Framework_TestCase
+class AddTest extends TestCase
 {
     public function test_add_item_creates_new_col_with_item()
     {

--- a/tests/Collection/ClearTest.php
+++ b/tests/Collection/ClearTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ClearTest extends PHPUnit_Framework_TestCase
+class ClearTest extends TestCase
 {
     public function test_clear_returns_an_empty_collection()
     {

--- a/tests/Collection/ContainsTest.php
+++ b/tests/Collection/ContainsTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ContainsTest extends PHPUnit_Framework_TestCase
+class ContainsTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/DropRightTest.php
+++ b/tests/Collection/DropRightTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class DropRightTest extends PHPUnit_Framework_TestCase
+class DropRightTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/DropTest.php
+++ b/tests/Collection/DropTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class DropTest extends PHPUnit_Framework_TestCase
+class DropTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/DropWhileTest.php
+++ b/tests/Collection/DropWhileTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class DropWhileTest extends PHPUnit_Framework_TestCase
+class DropWhileTest extends TestCase
 {
     public function test_drop_while()
     {

--- a/tests/Collection/EachTest.php
+++ b/tests/Collection/EachTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class EachTest extends PHPUnit_Framework_TestCase
+class EachTest extends TestCase
 {
     public function test_each()
     {

--- a/tests/Collection/EveryTest.php
+++ b/tests/Collection/EveryTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class EveryTest extends PHPUnit_Framework_TestCase
+class EveryTest extends TestCase
 {
     public function testEvery()
     {

--- a/tests/Collection/FindAllTest.php
+++ b/tests/Collection/FindAllTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FindAllTest extends PHPUnit_Framework_TestCase
+class FindAllTest extends TestCase
 {
     public function testFindAll()
     {

--- a/tests/Collection/FindIndexTest.php
+++ b/tests/Collection/FindIndexTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FindIndexTest extends PHPUnit_Framework_TestCase
+class FindIndexTest extends TestCase
 {
     public function testFindIndex()
     {

--- a/tests/Collection/FindLastTest.php
+++ b/tests/Collection/FindLastTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FindLastTest extends PHPUnit_Framework_TestCase
+class FindLastTest extends TestCase
 {
     public function testFindLast()
     {

--- a/tests/Collection/FindTest.php
+++ b/tests/Collection/FindTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FindTest extends PHPUnit_Framework_TestCase
+class FindTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/FirstAndLastTest.php
+++ b/tests/Collection/FirstAndLastTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FirstAndLastTest extends PHPUnit_Framework_TestCase
+class FirstAndLastTest extends TestCase
 {
     public function test_can_get_first_item()
     {

--- a/tests/Collection/GetIteratorTest.php
+++ b/tests/Collection/GetIteratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class GetIteratorTest extends PHPUnit_Framework_TestCase
+class GetIteratorTest extends TestCase
 {
     public function testIterator()
     {

--- a/tests/Collection/GetObjectNameTest.php
+++ b/tests/Collection/GetObjectNameTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class GetObjectNameTest extends PHPUnit_Framework_TestCase
+class GetObjectNameTest extends TestCase
 {
     public function testGetObjectName()
     {

--- a/tests/Collection/IndexExistsTest.php
+++ b/tests/Collection/IndexExistsTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class IndexExistsTest extends PHPUnit_Framework_TestCase
+class IndexExistsTest extends TestCase
 {
     public function testIndexExits()
     {

--- a/tests/Collection/InsertRangeTest.php
+++ b/tests/Collection/InsertRangeTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class InsertRangeTest extends PHPUnit_Framework_TestCase
+class InsertRangeTest extends TestCase
 {
     public function testInsert()
     {

--- a/tests/Collection/InsertTest.php
+++ b/tests/Collection/InsertTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class InsertTest extends PHPUnit_Framework_TestCase
+class InsertTest extends TestCase
 {
     public function testInsert()
     {

--- a/tests/Collection/MapTest.php
+++ b/tests/Collection/MapTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class MapTest extends PHPUnit_Framework_TestCase
+class MapTest extends TestCase
 {
     public function test_map_ints()
     {
@@ -62,7 +63,7 @@ class MapTest extends PHPUnit_Framework_TestCase
 
         $count = 0;
         $result = $c->map(function ($a) use (&$count) { return $count++; });
-       
+
         $expected = (new Collection('integer'))
                         ->add(0)
                         ->add(1)

--- a/tests/Collection/MergeTest.php
+++ b/tests/Collection/MergeTest.php
@@ -2,8 +2,9 @@
 
 use Collections\Collection;
 use Collections\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class MergeTest extends PHPUnit_Framework_TestCase
+class MergeTest extends TestCase
 {
     public function test_merge()
     {

--- a/tests/Collection/PopPopTest.php
+++ b/tests/Collection/PopPopTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class PopPopTest extends PHPUnit_Framework_TestCase
+class PopPopTest extends TestCase
 {
     public function test_pop_pop()
     {

--- a/tests/Collection/ReduceRightTest.php
+++ b/tests/Collection/ReduceRightTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ReduceRightTest extends PHPUnit_Framework_TestCase
+class ReduceRightTest extends TestCase
 {
     public function test_reduce_right_add()
     {

--- a/tests/Collection/ReduceTest.php
+++ b/tests/Collection/ReduceTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ReduceTest extends PHPUnit_Framework_TestCase
+class ReduceTest extends TestCase
 {
     public function testReduce()
     {

--- a/tests/Collection/RemoveAtTest.php
+++ b/tests/Collection/RemoveAtTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class RemoveAtTest extends PHPUnit_Framework_TestCase
+class RemoveAtTest extends TestCase
 {
    public function testRemoveAt()
     {

--- a/tests/Collection/ReverseTest.php
+++ b/tests/Collection/ReverseTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ReverseTest extends PHPUnit_Framework_TestCase
+class ReverseTest extends TestCase
 {
 
     public function testReverse()

--- a/tests/Collection/ShuffleTest.php
+++ b/tests/Collection/ShuffleTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ShuffleTest extends PHPUnit_Framework_TestCase
+class ShuffleTest extends TestCase
 {
     public function test_shuffle()
     {

--- a/tests/Collection/SliceTest.php
+++ b/tests/Collection/SliceTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class SliceTest extends PHPUnit_Framework_TestCase
+class SliceTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/SortTest.php
+++ b/tests/Collection/SortTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class SortTest extends PHPUnit_Framework_TestCase
+class SortTest extends TestCase
 {
     public function test_sorts_with_callback()
     {

--- a/tests/Collection/TailTest.php
+++ b/tests/Collection/TailTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class TailTest extends PHPUnit_Framework_TestCase
+class TailTest extends TestCase
 {
     public function test_that_tail_gives_you_everything_but_head()
     {

--- a/tests/Collection/TakeRightTest.php
+++ b/tests/Collection/TakeRightTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class TakeRightTest extends PHPUnit_Framework_TestCase
+class TakeRightTest extends TestCase
 {
     public function testTakeRight()
     {

--- a/tests/Collection/TakeTest.php
+++ b/tests/Collection/TakeTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FancyTest extends PHPUnit_Framework_TestCase
+class FancyTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/TakeWhileTest.php
+++ b/tests/Collection/TakeWhileTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class TakeWhileTest extends PHPUnit_Framework_TestCase
+class TakeWhileTest extends TestCase
 {
     public function test_take_while()
     {

--- a/tests/Collection/ToArrayTest.php
+++ b/tests/Collection/ToArrayTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ToArrayTest extends PHPUnit_Framework_TestCase
+class ToArrayTest extends TestCase
 {
     public function testToArray()
     {

--- a/tests/Collection/WithoutTest.php
+++ b/tests/Collection/WithoutTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class WithoutTest extends PHPUnit_Framework_TestCase
+class WithoutTest extends TestCase
 {
     public function test_without_returns_items_that_do_not_match_criteria()
     {

--- a/tests/Dictionary/AddTest.php
+++ b/tests/Dictionary/AddTest.php
@@ -4,12 +4,12 @@ namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
 use Collections\Exceptions\InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TestClassA;
 use TestClassAInterface;
 use TestClassExtendsA;
 
-class AddTest extends PHPUnit_Framework_TestCase
+class AddTest extends TestCase
 {
     public function test_adding_with_okay_types_adds_to_dictionary()
     {

--- a/tests/Dictionary/ClearTest.php
+++ b/tests/Dictionary/ClearTest.php
@@ -2,10 +2,10 @@
 
 namespace Collections\Tests\Dictionary;
 
-
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class ClearTest extends \PHPUnit_Framework_TestCase
+class ClearTest extends TestCase
 {
     public function test_clear_creates_empty_dictionary_of_same_type()
     {

--- a/tests/Dictionary/ContainsTest.php
+++ b/tests/Dictionary/ContainsTest.php
@@ -4,12 +4,12 @@ namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
 use Collections\Exceptions\InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TestClassA;
 use TestClassAInterface;
 use TestClassExtendsA;
 
-class ContainsTest extends PHPUnit_Framework_TestCase
+class ContainsTest extends TestCase
 {
     public function test_adding_with_okay_types_adds_to_dictionary()
     {

--- a/tests/Dictionary/DeleteTest.php
+++ b/tests/Dictionary/DeleteTest.php
@@ -3,9 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class DeleteTest extends PHPUnit_Framework_TestCase
+class DeleteTest extends TestCase
 {
     public function test_delete_key_creates_second_dic_without_key()
     {

--- a/tests/Dictionary/EachTest.php
+++ b/tests/Dictionary/EachTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class EachTest extends \PHPUnit_Framework_TestCase
+class EachTest extends TestCase
 {
     public function test_fn_applied_to_every_item()
     {

--- a/tests/Dictionary/ExistsTest.php
+++ b/tests/Dictionary/ExistsTest.php
@@ -2,10 +2,10 @@
 
 namespace Collections\Tests\Dictionary;
 
-
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class ExistsTest extends \PHPUnit_Framework_TestCase
+class ExistsTest extends TestCase
 {
     public function test_key_exists_returns_true()
     {

--- a/tests/Dictionary/FilterTest.php
+++ b/tests/Dictionary/FilterTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class FilterTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends TestCase
 {
     public function test_filter()
     {

--- a/tests/Dictionary/GetOrElseTest.php
+++ b/tests/Dictionary/GetOrElseTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class GetOrElseTest extends \PHPUnit_Framework_TestCase
+class GetOrElseTest extends TestCase
 {
     public function test_get_or_else()
     {

--- a/tests/Dictionary/KeysTest.php
+++ b/tests/Dictionary/KeysTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class KeysTest extends \PHPUnit_Framework_TestCase
+class KeysTest extends TestCase
 {
     public function test_keys()
     {

--- a/tests/Dictionary/MapTest.php
+++ b/tests/Dictionary/MapTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class MapTest extends \PHPUnit_Framework_TestCase
+class MapTest extends TestCase
 {
     public function test_map_infers_type_for_dict()
     {

--- a/tests/Dictionary/MergeTest.php
+++ b/tests/Dictionary/MergeTest.php
@@ -4,8 +4,9 @@ namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
 use Collections\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class MergeTest extends \PHPUnit_Framework_TestCase
+class MergeTest extends TestCase
 {
     public function test_can_merge_dict()
     {

--- a/tests/Dictionary/ReduceTest.php
+++ b/tests/Dictionary/ReduceTest.php
@@ -4,12 +4,12 @@ namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
 use Collections\Exceptions\InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TestClassA;
 use TestClassAInterface;
 use TestClassExtendsA;
 
-class ReduceTest extends PHPUnit_Framework_TestCase
+class ReduceTest extends TestCase
 {
     public function test_adding_with_okay_types_adds_to_dictionary()
     {

--- a/tests/Dictionary/ToArrayTest.php
+++ b/tests/Dictionary/ToArrayTest.php
@@ -2,10 +2,10 @@
 
 namespace Collections\Tests\Dictionary;
 
-
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class ToArrayTest extends \PHPUnit_Framework_TestCase
+class ToArrayTest extends TestCase
 {
     public function test_to_array_returns_assoc_array()
     {

--- a/tests/Dictionary/ValuesTest.php
+++ b/tests/Dictionary/ValuesTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class ValuesTest extends \PHPUnit_Framework_TestCase
+class ValuesTest extends TestCase
 {
     public function test_values()
     {

--- a/tests/Dictionary/WithoutTest.php
+++ b/tests/Dictionary/WithoutTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class WithoutTest extends \PHPUnit_Framework_TestCase
+class WithoutTest extends TestCase
 {
     public function test_filter()
     {

--- a/tests/HeadAndTailTest.php
+++ b/tests/HeadAndTailTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class HeadAndTailTest extends PHPUnit_Framework_TestCase
+class HeadAndTailTest extends TestCase
 {
     public function test_head_and_tail_returns_head_and_collection_for_tail()
     {


### PR DESCRIPTION
I used the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase`. This will help to migrate to `PHPUnit 6`, when decide, that [no longer support the snake case class name](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just needed to bump PHPUnit version to [`^5.4.3`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.4.md#543---2016-06-09), that supports this `namespace`.