### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: php
 php:
+  - '5.4'
+  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
+  - nightly
 
+matrix:
+  allow_failures:
+    - php: nightly
 before_script:
-  - composer install
+  - composer update -n
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
        }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.3",
+        "phpunit/phpunit": "^4.8|^5.3|^6.5",
         "squizlabs/php_codesniffer": "2.*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,25 +1,24 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "870859fabc3a9e63dae0871fd25cff05",
-    "content-hash": "c5d0c7e7bc2722e1ab4dbb2ffdbc7480",
+    "content-hash": "e2bbfdbfbba893c25251d8643adad353",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "dev-master",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "416fb8ad1d095a87f1d21bc40711843cd122fd4a"
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/416fb8ad1d095a87f1d21bc40711843cd122fd4a",
-                "reference": "416fb8ad1d095a87f1d21bc40711843cd122fd4a",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
                 "shasum": ""
             },
             "require": {
@@ -60,83 +59,90 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2016-03-31 10:24:22"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
-            "name": "myclabs/deep-copy",
-            "version": "1.5.1",
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "a8773992b362b58498eed24bf85005f363c34771"
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/a8773992b362b58498eed24bf85005f363c34771",
-                "reference": "a8773992b362b58498eed24bf85005f363c34771",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
             ],
-            "time": "2015-11-20 12:04:31"
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.3.0",
+                "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
                         "src/"
                     ]
                 }
@@ -148,10 +154,58 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-08-08T06:39:58+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-06-03T08:32:36+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -159,28 +213,29 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "f9a8140d6cf86514a64fb3b637e716008e1885d0"
+                "reference": "5d4764d0b9beb04d5b36801c868cfc79a12c70a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/f9a8140d6cf86514a64fb3b637e716008e1885d0",
-                "reference": "f9a8140d6cf86514a64fb3b637e716008e1885d0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/5d4764d0b9beb04d5b36801c868cfc79a12c70a3",
+                "reference": "5d4764d0b9beb04d5b36801c868cfc79a12c70a3",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1",
-                "sebastian/recursion-context": "~1.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -213,44 +268,43 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-05-27 08:33:35"
+            "time": "2018-04-19T14:17:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "dev-master",
+            "version": "2.2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "844ec6eabee15768f1e34a8871f6fddfc3d5f602"
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/844ec6eabee15768f1e34a8871f6fddfc3d5f602",
-                "reference": "844ec6eabee15768f1e34a8871f6fddfc3d5f602",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": ">=5.3.3",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "^1.4.2",
-                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "phpunit/php-token-stream": "~1.3",
                 "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0|~2.0"
+                "sebastian/version": "~1.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "~4"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.4.0",
+                "ext-xdebug": ">=2.2.1",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -276,20 +330,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-27 16:21:40"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "dev-master",
+            "version": "1.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -323,7 +377,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -364,29 +418,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "9513098641797ce5f459dbc1de5a54c29b0ec1fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/9513098641797ce5f459dbc1de5a54c29b0ec1fb",
+                "reference": "9513098641797ce5f459dbc1de5a54c29b0ec1fb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -408,20 +467,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2018-01-06T05:27:16+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "dev-master",
+            "version": "1.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "cab6c6fefee93d7b7c3a01292a0fe0884ea66644"
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/cab6c6fefee93d7b7c3a01292a0fe0884ea66644",
-                "reference": "cab6c6fefee93d7b7c3a01292a0fe0884ea66644",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/58bd196ce8bc49389307b3787934a5117db80fea",
+                "reference": "58bd196ce8bc49389307b3787934a5117db80fea",
                 "shasum": ""
             },
             "require": {
@@ -457,20 +516,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-23 14:46:55"
+            "time": "2017-12-04T15:11:28+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "dev-master",
+            "version": "4.8.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c5f916fea37634a027b091d533fce4f7ff3f49fc"
+                "reference": "18e5f52e8412d23e739f7d8744e177039860e800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c5f916fea37634a027b091d533fce4f7ff3f49fc",
-                "reference": "c5f916fea37634a027b091d533fce4f7ff3f49fc",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/18e5f52e8412d23e739f7d8744e177039860e800",
+                "reference": "18e5f52e8412d23e739f7d8744e177039860e800",
                 "shasum": ""
             },
             "require": {
@@ -479,22 +538,19 @@
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
+                "php": ">=5.3.3",
                 "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "^4.0",
+                "phpunit/php-code-coverage": "~2.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "~1.1",
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
-                "sebastian/object-enumerator": "~1.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0|~2.0",
+                "sebastian/version": "~1.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
             "suggest": {
@@ -506,7 +562,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4.x-dev"
+                    "dev-master": "4.8.x-dev"
                 }
             },
             "autoload": {
@@ -532,30 +588,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-31 04:34:31"
+            "time": "2017-06-23T12:44:27+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "dev-master",
+            "version": "2.3.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "5bf0ba29dd683ec4f2e5d4fb212ad31827501012"
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5bf0ba29dd683ec4f2e5d4fb212ad31827501012",
-                "reference": "5bf0ba29dd683ec4f2e5d4fb212ad31827501012",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2"
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "~4.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -563,7 +619,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -588,71 +644,26 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-05-26 06:15:46"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "dev-master",
+            "version": "1.2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "18a5d97c25f408f48acaf6d1b9f4079314c5996a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/18a5d97c25f408f48acaf6d1b9f4079314c5996a",
+                "reference": "18a5d97c25f408f48acaf6d1b9f4079314c5996a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -697,27 +708,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2017-03-07T10:34:43+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "dev-master",
+            "version": "1.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -749,27 +760,27 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2017-05-22T07:24:03+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "dev-master",
+            "version": "1.3.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "67f55699c2810ff0f2cc47478bbdeda8567e68ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/67f55699c2810ff0f2cc47478bbdeda8567e68ee",
+                "reference": "67f55699c2810ff0f2cc47478bbdeda8567e68ee",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -799,34 +810,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2017-02-28T08:18:59+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "dev-master",
+            "version": "1.2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "f88f8936517d54ae6d589166810877fb2015d0a2"
+                "reference": "dcd43bcc0fd3551bd2ede0081882d549bb78225d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f88f8936517d54ae6d589166810877fb2015d0a2",
-                "reference": "f88f8936517d54ae6d589166810877fb2015d0a2",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/dcd43bcc0fd3551bd2ede0081882d549bb78225d",
+                "reference": "dcd43bcc0fd3551bd2ede0081882d549bb78225d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^5.3.3 || ^7.0",
+                "sebastian/recursion-context": "^1.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -866,27 +877,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-08-09 04:23:41"
+            "time": "2017-02-26T13:09:30+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "1.1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "cea85a84b00f2795341ebbbca4fa396347f2494e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/cea85a84b00f2795341ebbbca4fa396347f2494e",
+                "reference": "cea85a84b00f2795341ebbbca4fa396347f2494e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.2|~5.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -917,66 +928,20 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
-        },
-        {
-            "name": "sebastian/object-enumerator",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
+            "time": "2017-02-23T14:11:06+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "dev-master",
+            "version": "1.0.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "7ff5b1b3dcc55b8ab8ae61ef99d4730940856ee7"
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/7ff5b1b3dcc55b8ab8ae61ef99d4730940856ee7",
-                "reference": "7ff5b1b3dcc55b8ab8ae61ef99d4730940856ee7",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
                 "shasum": ""
             },
             "require": {
@@ -1016,73 +981,23 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-01-28 05:39:29"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "dev-master",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
-                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
                 "shasum": ""
             },
-            "require": {
-                "php": ">=5.6"
-            },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1101,20 +1016,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-02-04 12:56:52"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "dev-master",
+            "version": "2.9.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2d3a4a80cc7df70884ba072dfecda7028b37f1d0"
+                "reference": "8a457eb0e3dcd366b85fd0ee1e6509cf17e47814"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2d3a4a80cc7df70884ba072dfecda7028b37f1d0",
-                "reference": "2d3a4a80cc7df70884ba072dfecda7028b37f1d0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/8a457eb0e3dcd366b85fd0ee1e6509cf17e47814",
+                "reference": "8a457eb0e3dcd366b85fd0ee1e6509cf17e47814",
                 "shasum": ""
             },
             "require": {
@@ -1179,29 +1094,38 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-06-01 09:46:56"
+            "time": "2018-02-11T23:06:14+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "dev-master",
+            "version": "3.4.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "737c6a22a9a2f6ac3d4c62a0b97720e139c4a093"
+                "reference": "033cfa61ef06ee0847e056e530201842b6e926c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/737c6a22a9a2f6ac3d4c62a0b97720e139c4a093",
-                "reference": "737c6a22a9a2f6ac3d4c62a0b97720e139c4a093",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/033cfa61ef06ee0847e056e530201842b6e926c3",
+                "reference": "033cfa61ef06ee0847e056e530201842b6e926c3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1228,7 +1152,57 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-29 09:50:57"
+            "time": "2018-04-08T08:21:29+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "23bf61bc8a7cc229d7ce8689b1bf818a9e192cac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/23bf61bc8a7cc229d7ce8689b1bf818a9e192cac",
+                "reference": "23bf61bc8a7cc229d7ce8689b1bf818a9e192cac",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-04-19T15:46:26+00:00"
         }
     ],
     "aliases": [],

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -337,7 +337,6 @@ class Collection implements CollectionInterface
         $col->setItemsFromTrustedSource($items);
 
         return $col;
-
     }
 
     /**

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -142,7 +142,7 @@ class Dictionary implements DictionaryInterface
     public function without(callable $condition)
     {
         $inverse = function ($k, $v) use ($condition) {
-            return !$condition($k,$v);
+            return !$condition($k, $v);
         };
 
         return $this->filter($inverse);

--- a/tests/Collection/AccessTest.php
+++ b/tests/Collection/AccessTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class AccessTest extends PHPUnit_Framework_TestCase
+class AccessTest extends TestCase
 {
     /**
      * @expectedException Collections\Exceptions\InvalidArgumentException

--- a/tests/Collection/AddTest.php
+++ b/tests/Collection/AddTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class AddTest extends PHPUnit_Framework_TestCase
+class AddTest extends TestCase
 {
     public function test_add_item_creates_new_col_with_item()
     {

--- a/tests/Collection/ClearTest.php
+++ b/tests/Collection/ClearTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ClearTest extends PHPUnit_Framework_TestCase
+class ClearTest extends TestCase
 {
     public function test_clear_returns_an_empty_collection()
     {

--- a/tests/Collection/ContainsTest.php
+++ b/tests/Collection/ContainsTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ContainsTest extends PHPUnit_Framework_TestCase
+class ContainsTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/DropRightTest.php
+++ b/tests/Collection/DropRightTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class DropRightTest extends PHPUnit_Framework_TestCase
+class DropRightTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/DropTest.php
+++ b/tests/Collection/DropTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class DropTest extends PHPUnit_Framework_TestCase
+class DropTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/DropWhileTest.php
+++ b/tests/Collection/DropWhileTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class DropWhileTest extends PHPUnit_Framework_TestCase
+class DropWhileTest extends TestCase
 {
     public function test_drop_while()
     {

--- a/tests/Collection/EachTest.php
+++ b/tests/Collection/EachTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class EachTest extends PHPUnit_Framework_TestCase
+class EachTest extends TestCase
 {
     public function test_each()
     {

--- a/tests/Collection/EveryTest.php
+++ b/tests/Collection/EveryTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class EveryTest extends PHPUnit_Framework_TestCase
+class EveryTest extends TestCase
 {
     public function testEvery()
     {

--- a/tests/Collection/FindAllTest.php
+++ b/tests/Collection/FindAllTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FindAllTest extends PHPUnit_Framework_TestCase
+class FindAllTest extends TestCase
 {
     public function testFindAll()
     {

--- a/tests/Collection/FindIndexTest.php
+++ b/tests/Collection/FindIndexTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FindIndexTest extends PHPUnit_Framework_TestCase
+class FindIndexTest extends TestCase
 {
     public function testFindIndex()
     {

--- a/tests/Collection/FindLastTest.php
+++ b/tests/Collection/FindLastTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FindLastTest extends PHPUnit_Framework_TestCase
+class FindLastTest extends TestCase
 {
     public function testFindLast()
     {

--- a/tests/Collection/FindTest.php
+++ b/tests/Collection/FindTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FindTest extends PHPUnit_Framework_TestCase
+class FindTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/FirstAndLastTest.php
+++ b/tests/Collection/FirstAndLastTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FirstAndLastTest extends PHPUnit_Framework_TestCase
+class FirstAndLastTest extends TestCase
 {
     public function test_can_get_first_item()
     {

--- a/tests/Collection/GetIteratorTest.php
+++ b/tests/Collection/GetIteratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class GetIteratorTest extends PHPUnit_Framework_TestCase
+class GetIteratorTest extends TestCase
 {
     public function testIterator()
     {

--- a/tests/Collection/GetObjectNameTest.php
+++ b/tests/Collection/GetObjectNameTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class GetObjectNameTest extends PHPUnit_Framework_TestCase
+class GetObjectNameTest extends TestCase
 {
     public function testGetObjectName()
     {

--- a/tests/Collection/IndexExistsTest.php
+++ b/tests/Collection/IndexExistsTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class IndexExistsTest extends PHPUnit_Framework_TestCase
+class IndexExistsTest extends TestCase
 {
     public function testIndexExits()
     {
@@ -15,16 +16,22 @@ class IndexExistsTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($col->indexExists(2));
     }
 
+    /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     * @expectedExceptionMessage Index must be a non-negative integer
+     */
     public function testIndexExitsRejectsNegatives()
     {
-        $this->setExpectedException("Collections\Exceptions\InvalidArgumentException");
         $col = new Collection('TestClassA');
         $col->indexExists(-1);
     }
 
+    /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     * @expectedExceptionMessage Index must be an integer
+     */
     public function testIndexExitsRejectsNonIntegers()
     {
-        $this->setExpectedException("Collections\Exceptions\InvalidArgumentException");
         $col = new Collection('TestClassA');
         $col->indexExists("wat");
     }

--- a/tests/Collection/InsertRangeTest.php
+++ b/tests/Collection/InsertRangeTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class InsertRangeTest extends PHPUnit_Framework_TestCase
+class InsertRangeTest extends TestCase
 {
     public function testInsert()
     {

--- a/tests/Collection/InsertTest.php
+++ b/tests/Collection/InsertTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class InsertTest extends PHPUnit_Framework_TestCase
+class InsertTest extends TestCase
 {
     public function testInsert()
     {
@@ -13,11 +14,25 @@ class InsertTest extends PHPUnit_Framework_TestCase
         $result = $c->insert(1, new TestClassA(3));
 
         $this->assertEquals(3, $result->at(1)->getValue());
+    }
 
-        $this->setExpectedException("Collections\Exceptions\OutOfRangeException");
+    /**
+     * @expectedException Collections\Exceptions\OutOfRangeException
+     * @expectedExceptionMessage Index out of bounds of collection
+     */
+    public function testInsertThrowsOutOfRangeException()
+    {
+        $c = new Collection('TestClassA');
         $c->insert(100, new TestClassA(5));
+    }
 
-        $this->setExpectedException("Collections\Exceptions\InvalidArgumentException");
+    /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     * @expectedExceptionMessage Index must be a non-negative integer
+     */
+    public function testInsertThrowsInvalidArgumentException()
+    {
+        $c = new Collection('TestClassA');
         $c->insert(-1, new TestClassA(5));
     }
 }

--- a/tests/Collection/MapTest.php
+++ b/tests/Collection/MapTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class MapTest extends PHPUnit_Framework_TestCase
+class MapTest extends TestCase
 {
     public function test_map_ints()
     {

--- a/tests/Collection/MergeTest.php
+++ b/tests/Collection/MergeTest.php
@@ -2,8 +2,9 @@
 
 use Collections\Collection;
 use Collections\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class MergeTest extends PHPUnit_Framework_TestCase
+class MergeTest extends TestCase
 {
     public function test_merge()
     {
@@ -59,9 +60,11 @@ class MergeTest extends PHPUnit_Framework_TestCase
         $col->merge($badItems);
     }
 
+    /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_non_array_or_col_throws_ex()
     {
-        $this->expectException(InvalidArgumentException::class);
         $col = new Collection('TestClassA');
         $col->merge(new TestClassA(1));
     }

--- a/tests/Collection/PopPopTest.php
+++ b/tests/Collection/PopPopTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class PopPopTest extends PHPUnit_Framework_TestCase
+class PopPopTest extends TestCase
 {
     public function test_pop_pop()
     {

--- a/tests/Collection/ReduceRightTest.php
+++ b/tests/Collection/ReduceRightTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ReduceRightTest extends PHPUnit_Framework_TestCase
+class ReduceRightTest extends TestCase
 {
     public function test_reduce_right_add()
     {

--- a/tests/Collection/ReduceTest.php
+++ b/tests/Collection/ReduceTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ReduceTest extends PHPUnit_Framework_TestCase
+class ReduceTest extends TestCase
 {
     public function testReduce()
     {

--- a/tests/Collection/RemoveAtTest.php
+++ b/tests/Collection/RemoveAtTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class RemoveAtTest extends PHPUnit_Framework_TestCase
+class RemoveAtTest extends TestCase
 {
    public function testRemoveAt()
     {

--- a/tests/Collection/ReverseTest.php
+++ b/tests/Collection/ReverseTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ReverseTest extends PHPUnit_Framework_TestCase
+class ReverseTest extends TestCase
 {
 
     public function testReverse()

--- a/tests/Collection/ShuffleTest.php
+++ b/tests/Collection/ShuffleTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ShuffleTest extends PHPUnit_Framework_TestCase
+class ShuffleTest extends TestCase
 {
     public function test_shuffle()
     {

--- a/tests/Collection/SliceTest.php
+++ b/tests/Collection/SliceTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class SliceTest extends PHPUnit_Framework_TestCase
+class SliceTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/SortTest.php
+++ b/tests/Collection/SortTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class SortTest extends PHPUnit_Framework_TestCase
+class SortTest extends TestCase
 {
     public function test_sorts_with_callback()
     {

--- a/tests/Collection/TailTest.php
+++ b/tests/Collection/TailTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class TailTest extends PHPUnit_Framework_TestCase
+class TailTest extends TestCase
 {
     public function test_that_tail_gives_you_everything_but_head()
     {

--- a/tests/Collection/TakeRightTest.php
+++ b/tests/Collection/TakeRightTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class TakeRightTest extends PHPUnit_Framework_TestCase
+class TakeRightTest extends TestCase
 {
     public function testTakeRight()
     {

--- a/tests/Collection/TakeTest.php
+++ b/tests/Collection/TakeTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class FancyTest extends PHPUnit_Framework_TestCase
+class FancyTest extends TestCase
 {
     /**
      * @var Collection

--- a/tests/Collection/TakeWhileTest.php
+++ b/tests/Collection/TakeWhileTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class TakeWhileTest extends PHPUnit_Framework_TestCase
+class TakeWhileTest extends TestCase
 {
     public function test_take_while()
     {

--- a/tests/Collection/ToArrayTest.php
+++ b/tests/Collection/ToArrayTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class ToArrayTest extends PHPUnit_Framework_TestCase
+class ToArrayTest extends TestCase
 {
     public function testToArray()
     {

--- a/tests/Collection/WithoutTest.php
+++ b/tests/Collection/WithoutTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class WithoutTest extends PHPUnit_Framework_TestCase
+class WithoutTest extends TestCase
 {
     public function test_without_returns_items_that_do_not_match_criteria()
     {

--- a/tests/Dictionary/AddTest.php
+++ b/tests/Dictionary/AddTest.php
@@ -4,12 +4,12 @@ namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
 use Collections\Exceptions\InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TestClassA;
 use TestClassAInterface;
 use TestClassExtendsA;
 
-class AddTest extends PHPUnit_Framework_TestCase
+class AddTest extends TestCase
 {
     public function test_adding_with_okay_types_adds_to_dictionary()
     {
@@ -54,7 +54,7 @@ class AddTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, $d->count());
 
         //class works as value type
-        $d = new Dictionary('string', TestClassA::class);
+        $d = new Dictionary('string', 'TestClassA');
         $d = $d->add('test', new TestClassA(42));
         $this->assertEquals(1, $d->count());
 
@@ -63,64 +63,82 @@ class AddTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, $d->count());
 
         //interface works as value type
-        $d = new Dictionary('string', TestClassAInterface::class);
+        $d = new Dictionary('string', 'TestClassAInterface');
         $d = $d->add('test', new TestClassA(42));
         $this->assertEquals(1, $d->count());
     }
 
+    /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_adding_with_invalid_key_type_throws_ex()
     {
-        $this->expectException(InvalidArgumentException::class);
         $d = new dictionary('string', 'int');
         $d = $d->add(4, 1977);
     }
 
+    /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_adding_with_invalid_value_type_throws_ex()
     {
-        $this->expectException(InvalidArgumentException::class);
         $d = new dictionary('string', 'string');
         $d = $d->add("Episode IV", 1977);
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_array_is_invalid_key_type()
     {
-        $this->expectException(InvalidArgumentException::class);
         $d = new Dictionary('array', 'int');
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_object_is_invalid_key_type()
     {
-        $this->expectException(InvalidArgumentException::class);
         $d = new Dictionary('object', 'int');
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_callable_is_invalid_key_type()
     {
-        $this->expectException(InvalidArgumentException::class);
         $d = new Dictionary('callable', 'int');
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_class_is_invalid_key_type()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $d = new Dictionary(TestClassA::class, 'int');
+        $d = new Dictionary('TestClassA', 'int');
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_interface_is_invalid_key_type()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $d = new Dictionary(TestClassAInterface::class, 'int');
+        $d = new Dictionary('TestClassAInterface', 'int');
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_madeup_string_is_invalid_key_type()
     {
-        $this->expectException(InvalidArgumentException::class);
         $d = new Dictionary('test2', 'int');
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_float_is_invalid_key_type()
     {
-        $this->expectException(InvalidArgumentException::class);
         $d = new Dictionary('float', 'int');
     }
 
@@ -132,9 +150,11 @@ class AddTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, $d->get('key'));
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_ex_thrown_if_callable_is_not_passed()
     {
-        $this->expectException(InvalidArgumentException::class);
         $d = new Dictionary('string', 'callable');
         $d = $d->add('test', 123);
     }

--- a/tests/Dictionary/ClearTest.php
+++ b/tests/Dictionary/ClearTest.php
@@ -4,8 +4,9 @@ namespace Collections\Tests\Dictionary;
 
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class ClearTest extends \PHPUnit_Framework_TestCase
+class ClearTest extends TestCase
 {
     public function test_clear_creates_empty_dictionary_of_same_type()
     {

--- a/tests/Dictionary/ContainsTest.php
+++ b/tests/Dictionary/ContainsTest.php
@@ -4,12 +4,12 @@ namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
 use Collections\Exceptions\InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TestClassA;
 use TestClassAInterface;
 use TestClassExtendsA;
 
-class ContainsTest extends PHPUnit_Framework_TestCase
+class ContainsTest extends TestCase
 {
     public function test_adding_with_okay_types_adds_to_dictionary()
     {

--- a/tests/Dictionary/DeleteTest.php
+++ b/tests/Dictionary/DeleteTest.php
@@ -3,9 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class DeleteTest extends PHPUnit_Framework_TestCase
+class DeleteTest extends TestCase
 {
     public function test_delete_key_creates_second_dic_without_key()
     {

--- a/tests/Dictionary/EachTest.php
+++ b/tests/Dictionary/EachTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class EachTest extends \PHPUnit_Framework_TestCase
+class EachTest extends TestCase
 {
     public function test_fn_applied_to_every_item()
     {

--- a/tests/Dictionary/ExistsTest.php
+++ b/tests/Dictionary/ExistsTest.php
@@ -4,8 +4,9 @@ namespace Collections\Tests\Dictionary;
 
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class ExistsTest extends \PHPUnit_Framework_TestCase
+class ExistsTest extends TestCase
 {
     public function test_key_exists_returns_true()
     {

--- a/tests/Dictionary/FilterTest.php
+++ b/tests/Dictionary/FilterTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class FilterTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends TestCase
 {
     public function test_filter()
     {

--- a/tests/Dictionary/GetOrElseTest.php
+++ b/tests/Dictionary/GetOrElseTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class GetOrElseTest extends \PHPUnit_Framework_TestCase
+class GetOrElseTest extends TestCase
 {
     public function test_get_or_else()
     {

--- a/tests/Dictionary/KeysTest.php
+++ b/tests/Dictionary/KeysTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class KeysTest extends \PHPUnit_Framework_TestCase
+class KeysTest extends TestCase
 {
     public function test_keys()
     {

--- a/tests/Dictionary/MapTest.php
+++ b/tests/Dictionary/MapTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class MapTest extends \PHPUnit_Framework_TestCase
+class MapTest extends TestCase
 {
     public function test_map_infers_type_for_dict()
     {

--- a/tests/Dictionary/MergeTest.php
+++ b/tests/Dictionary/MergeTest.php
@@ -4,8 +4,9 @@ namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
 use Collections\Exceptions\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class MergeTest extends \PHPUnit_Framework_TestCase
+class MergeTest extends TestCase
 {
     public function test_can_merge_dict()
     {
@@ -42,18 +43,22 @@ class MergeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $m->get('a'));
     }
 
+   /**
+     * @expectedException Collections\Exceptions\InvalidArgumentException
+     */
     public function test_merge_of_bad_types_fails()
     {
-        $this->expectException(InvalidArgumentException::class);
         $l = (new Dictionary('string','int'))->add('a',1);
         $r = (new Dictionary('string','string'))->add('b','2');
 
         $m = $l->merge($r);
     }
 
+   /**
+     * @expectedException \InvalidArgumentException
+     */
     public function test_merge_of_non_array()
     {
-        $this->expectException(\InvalidArgumentException::class);
         $d = (new Dictionary('string', 'int'))->add('a',1);
 
         $result = $d->merge(3);

--- a/tests/Dictionary/ReduceTest.php
+++ b/tests/Dictionary/ReduceTest.php
@@ -4,12 +4,12 @@ namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
 use Collections\Exceptions\InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use TestClassA;
 use TestClassAInterface;
 use TestClassExtendsA;
 
-class ReduceTest extends PHPUnit_Framework_TestCase
+class ReduceTest extends TestCase
 {
     public function test_adding_with_okay_types_adds_to_dictionary()
     {

--- a/tests/Dictionary/ToArrayTest.php
+++ b/tests/Dictionary/ToArrayTest.php
@@ -4,8 +4,9 @@ namespace Collections\Tests\Dictionary;
 
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class ToArrayTest extends \PHPUnit_Framework_TestCase
+class ToArrayTest extends TestCase
 {
     public function test_to_array_returns_assoc_array()
     {

--- a/tests/Dictionary/ValuesTest.php
+++ b/tests/Dictionary/ValuesTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class ValuesTest extends \PHPUnit_Framework_TestCase
+class ValuesTest extends TestCase
 {
     public function test_values()
     {

--- a/tests/Dictionary/WithoutTest.php
+++ b/tests/Dictionary/WithoutTest.php
@@ -3,8 +3,9 @@
 namespace Collections\Tests\Dictionary;
 
 use Collections\Dictionary;
+use PHPUnit\Framework\TestCase;
 
-class WithoutTest extends \PHPUnit_Framework_TestCase
+class WithoutTest extends TestCase
 {
     public function test_filter()
     {

--- a/tests/HeadAndTailTest.php
+++ b/tests/HeadAndTailTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Collections\Collection;
+use PHPUnit\Framework\TestCase;
 
-class HeadAndTailTest extends PHPUnit_Framework_TestCase
+class HeadAndTailTest extends TestCase
 {
     public function test_head_and_tail_returns_head_and_collection_for_tail()
     {
@@ -10,7 +11,7 @@ class HeadAndTailTest extends PHPUnit_Framework_TestCase
         list($h,$t) = $col->headAndTail();
 
         $this->assertEquals(1, $h);
-        $this->assertInstanceOf(Collection::class, $t);
+        $this->assertInstanceOf('Collections\Collection', $t);
         $this->assertEquals([2,3], $t->toArray());
     }
 


### PR DESCRIPTION
# Changed log
- Set muiltiple PHPUnit versions to support diffeent PHP versions.
- Set the nightly test and accept this can be failed in Travis CI build.
- Add the ```php-7.2``` test in Travis CI build.
- Use the class-based PHPUnit namespace to support the stable PHPUnit version.
- Add more tests.
- Use the annotation exception expectation to be compatible with the different PHP versions.