### PR TITLE
fix: type check in merge method. It should be checked by interface.

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -546,7 +546,7 @@ class Collection implements CollectionInterface
      */
     public function merge($items)
     {
-        if ($items instanceof static) {
+        if ($items instanceof CollectionInterface) {
             $items = $items->toArray();
         }
 


### PR DESCRIPTION
Hi, checking type in "Collection::merge" should be done by interface CollectionInterface. I created Lazy resolvable collection which implements ColectionInterface and wraps Collection. In this situation merge method is not working.